### PR TITLE
feat(domain): create user with handle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ implementación, preservando documentación, decisiones, backlog y tooling.
 ## Git
 
 - `main` es la rama principal de integración.
-- Se puede crear una branch corta por story desde `main`, con formato `story/<issue-number>-<slug>`.
+- Crear la branch corta por story desde GitHub con `gh issue develop`, basada
+  en `main` y con formato `story/<issue-number>-<slug>`.
 - Evitar ramas de larga vida.
 - Integrar cambios pequeños y frecuentes.
 - Hacer commits pequeños, atómicos y con una intención clara.

--- a/README.md
+++ b/README.md
@@ -53,18 +53,25 @@ historia activa.
 Buenas prácticas:
 
 - Integrar cambios pequeños en `main` frecuentemente.
-- Para cada story, se puede crear una branch corta desde `main`:
+- Para cada story, crear la branch desde GitHub para que quede vinculada al
+  issue:
 
   ```sh
   git switch main
   git pull --ff-only
-  git switch -c story/<issue-number>-<slug>
+  gh issue develop <issue-number> \
+    --name story/<issue-number>-<slug> \
+    --base main \
+    --checkout
   ```
 
 - Ejemplo:
 
   ```sh
-  git switch -c story/21-personal-room
+  gh issue develop 21 \
+    --name story/21-personal-room \
+    --base main \
+    --checkout
   ```
 
 - Evitar ramas de larga vida.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Labels principales:
 
 Historia activa:
 
-- [#20 Como usuario, quiero crear un usuario humano con handle](https://github.com/andrestobelem/pi-clojure/issues/20)
+- [#14 Como usuario, quiero crearme con un handle](https://github.com/andrestobelem/pi-clojure/issues/14)
 
 Procedimiento de trabajo:
 
@@ -114,7 +114,7 @@ con:
 gh project view 2 --owner andrestobelem --format json --jq '.id'
 gh project field-list 2 --owner andrestobelem --format json
 gh project item-list 2 --owner andrestobelem --format json --limit 100 \
-  --jq '.items[] | select(.content.number==20) | {id, status:.status, title:.content.title}'
+  --jq '.items[] | select(.content.number==14) | {id, status:.status, title:.content.title}'
 ```
 
 Mover un item a `Done`:

--- a/docs/research/2026-05-01-pairing-tdd-reset.md
+++ b/docs/research/2026-05-01-pairing-tdd-reset.md
@@ -15,7 +15,8 @@ borrar `src/` y `test/` si eso ayuda a recuperar claridad de diseño.
 - Trabajamos como pair programming: la persona usuaria decide intención y
   prioridad; el agente propone el siguiente micro-paso y ejecuta cambios.
 - Trabajamos de a una sola historia activa en GitHub Projects.
-- Podemos crear una branch corta por story desde `main`, con formato `story/<issue-number>-<slug>`.
+- Creamos la branch corta desde GitHub con `gh issue develop` para que quede
+  vinculada al issue, con formato `story/<issue-number>-<slug>`.
 - La historia se mueve a `In Progress` al comenzar y vuelve a `Todo` si pausamos
   antes de escribir o conservar código.
 - Cada cambio de comportamiento empieza con un test rojo visible.
@@ -38,14 +39,18 @@ Formato:
 Como <usuario>, quiero <capacidad>, para <beneficio>.
 ```
 
-### 2. Crear o verificar branch corta
+### 2. Crear o verificar branch corta desde GitHub
 
-Si vamos a usar branch por story, crearla desde `main` antes de escribir código:
+Si vamos a usar branch por story, crearla con GitHub CLI antes de escribir
+código para que quede vinculada al issue:
 
 ```sh
 git switch main
 git pull --ff-only
-git switch -c story/<issue-number>-<slug>
+gh issue develop <issue-number> \
+  --name story/<issue-number>-<slug> \
+  --base main \
+  --checkout
 ```
 
 La branch debe vivir poco y volver rápido a `main`.

--- a/docs/research/2026-05-01-username-policy.md
+++ b/docs/research/2026-05-01-username-policy.md
@@ -1,0 +1,108 @@
+# Política de nombres de usuario
+
+## Pregunta
+
+¿Cuál es el estado del arte para definir handles o nombres de usuario públicos?
+
+## Hallazgos
+
+### Separar identidad interna de handle público
+
+El identificador primario del usuario no debería ser el handle. NIST recomienda
+mantener una cuenta única y usar identificadores únicos generados con suficiente
+entropía. OWASP también recomienda que los user ids identifiquen unívocamente al
+usuario y que idealmente sean aleatorios.
+
+Decisión sugerida: usar en el futuro un `:user/id` opaco e inmutable, y tratar
+`:user/handle` como identificador público mutable o al menos no como clave
+primaria global del dominio.
+
+### Canonicalizar y validar en servidor
+
+Para handles públicos simples, el patrón más robusto es:
+
+- normalizar antes de validar y persistir;
+- guardar un `handle_canonical` o equivalente;
+- aplicar índice único sobre el valor canonicalizado;
+- no depender de collation específica de la base de datos;
+- comparar por el valor canonicalizado.
+
+Para nuestro slice actual, `trim` + `lower-case` + índice por handle normalizado
+va en esa dirección.
+
+### Preferir ASCII para handles nuevos
+
+Para un producto inicial, el enfoque más seguro y simple es restringir handles a
+ASCII URL-safe y dejar Unicode expresivo para un campo separado de display name.
+
+Una política común es permitir:
+
+- letras minúsculas `a-z`;
+- números `0-9`;
+- separadores limitados como `-` y/o `_`;
+- longitud mínima y máxima explícita;
+- sin separador al inicio o final;
+- sin separadores repetidos, si queremos URLs y lectura más limpias.
+
+GitHub, por ejemplo, limita usernames a 39 caracteres, permite caracteres
+alfanuméricos y guiones, y rechaza guiones al inicio/final, guiones consecutivos
+y colisiones tras normalización.
+
+### Unicode requiere una especificación, no una regex casera
+
+Si más adelante queremos handles Unicode, conviene adoptar una especificación
+existente:
+
+- PRECIS `UsernameCaseMapped` / `IdentifierClass`;
+- Unicode UTS #39 para seguridad de identificadores.
+
+Eso implica manejar normalización NFC, case mapping, bidireccionalidad,
+caracteres invisibles, caracteres no asignados, confusables y mezcla de scripts.
+No es recomendable improvisarlo con una regex propia.
+
+### Evitar impersonation y nombres reservados
+
+Además de la unicidad técnica, hay que considerar abuso e impersonation:
+
+- reservar handles del sistema: `admin`, `root`, `support`, `api`, `www`, etc.;
+- detectar o bloquear confusables si se permite Unicode;
+- evitar nombres que solo difieran por mayúsculas, espacios o caracteres
+  invisibles;
+- auditar cambios de handle si en el futuro son editables.
+
+### Evitar enumeración de usuarios en flujos sensibles
+
+OWASP recomienda respuestas genéricas en login, recuperación y registro cuando
+aplique, para no filtrar si un usuario existe. En nuestro dominio puede ser
+válido devolver `handle already exists` en creación, pero la capa pública deberá
+decidir si muestra ese detalle o una respuesta genérica según el contexto.
+
+## Recomendación para este repo ahora
+
+Mantener el slice simple con handles ASCII canonicalizados:
+
+- canonicalización: `trim` + `lower-case`;
+- caracteres: `a-z`, `0-9`, `-`, `_`;
+- unicidad sobre el handle canonicalizado;
+- agregar longitud mínima y máxima;
+- rechazar separador inicial/final;
+- rechazar separadores consecutivos si queremos una política más estricta;
+- documentar que el store actual es in-memory y que en persistencia real habrá
+  un índice único sobre el canonical handle;
+- crear más adelante `:user/id` opaco para no usar `:user/handle` como identidad
+  interna permanente.
+
+## Fuentes
+
+- NIST SP 800-63A-4, Subscriber Accounts:
+  <https://pages.nist.gov/800-63-4/sp800-63a/accounts/>
+- OWASP Authentication Cheat Sheet:
+  <https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html>
+- RFC 8265, PRECIS: Usernames and Passwords:
+  <https://www.ietf.org/rfc/rfc8265.html>
+- RFC 8264, PRECIS Framework:
+  <https://www.rfc-editor.org/rfc/rfc8264.html>
+- Unicode UTS #39, Unicode Security Mechanisms:
+  <https://unicode.org/reports/tr39/>
+- GitHub Enterprise Server Docs, Username considerations:
+  <https://docs.github.com/en/enterprise-server@3.17/admin/managing-iam/iam-configuration-reference/username-considerations-for-external-authentication>

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -5,14 +5,14 @@
          :type :user.type/human})
 
 (defn create-store []
-  (atom {}))
+  (atom #:users{:by-handle {}}))
 
 (defn find-by-handle [store handle]
-  (get @store handle))
+  (get-in @store [:users/by-handle handle]))
 
 (defn create-human! [store handle]
   (let [human-user (create-human handle)]
     (when (find-by-handle store handle)
       (throw (ex-info "handle already exists" {:handle handle})))
-    (swap! store assoc handle human-user)
+    (swap! store assoc-in [:users/by-handle handle] human-user)
     human-user))

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -21,6 +21,9 @@
     (throw (ex-info "handle is required" {:handle handle})))
   (let [normalized-handle (-> handle str/trim str/lower-case)
         human-user (create-human normalized-handle)]
+    (when-not (re-matches #"[a-z0-9_-]+" normalized-handle)
+      (throw (ex-info "handle has unsupported characters"
+                      {:handle normalized-handle})))
     (when (find-by-handle store normalized-handle)
       (throw (ex-info "handle already exists" {:handle normalized-handle})))
     (swap! store assoc-in [:users/by-handle normalized-handle] human-user)

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -19,7 +19,7 @@
 (defn create-human! [store handle]
   (when (str/blank? handle)
     (throw (ex-info "handle is required" {:handle handle})))
-  (let [normalized-handle (str/trim handle)
+  (let [normalized-handle (-> handle str/trim str/lower-case)
         human-user (create-human normalized-handle)]
     (when (find-by-handle store normalized-handle)
       (throw (ex-info "handle already exists" {:handle normalized-handle})))

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -19,8 +19,9 @@
 (defn create-human! [store handle]
   (when (str/blank? handle)
     (throw (ex-info "handle is required" {:handle handle})))
-  (let [human-user (create-human handle)]
-    (when (find-by-handle store handle)
-      (throw (ex-info "handle already exists" {:handle handle})))
-    (swap! store assoc-in [:users/by-handle handle] human-user)
+  (let [normalized-handle (str/trim handle)
+        human-user (create-human normalized-handle)]
+    (when (find-by-handle store normalized-handle)
+      (throw (ex-info "handle already exists" {:handle normalized-handle})))
+    (swap! store assoc-in [:users/by-handle normalized-handle] human-user)
     human-user))

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -11,6 +11,11 @@
 (defn find-by-handle [store handle]
   (get-in @store [:users/by-handle handle]))
 
+(defn list-users [store]
+  (->> (get-in @store [:users/by-handle])
+       (sort-by key)
+       (mapv val)))
+
 (defn create-human! [store handle]
   (when (str/blank? handle)
     (throw (ex-info "handle is required" {:handle handle})))

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -1,4 +1,5 @@
-(ns pi-clojure.domain.user)
+(ns pi-clojure.domain.user
+  (:require [clojure.string :as str]))
 
 (defn create-human [handle]
   #:user{:handle handle
@@ -11,6 +12,8 @@
   (get-in @store [:users/by-handle handle]))
 
 (defn create-human! [store handle]
+  (when (str/blank? handle)
+    (throw (ex-info "handle is required" {:handle handle})))
   (let [human-user (create-human handle)]
     (when (find-by-handle store handle)
       (throw (ex-info "handle already exists" {:handle handle})))

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -3,3 +3,16 @@
 (defn create-human [handle]
   #:user{:handle handle
          :type :user.type/human})
+
+(defn create-store []
+  (atom {}))
+
+(defn find-by-handle [store handle]
+  (get @store handle))
+
+(defn create-human! [store handle]
+  (let [human-user (create-human handle)]
+    (when (find-by-handle store handle)
+      (throw (ex-info "handle already exists" {:handle handle})))
+    (swap! store assoc handle human-user)
+    human-user))

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -49,7 +49,19 @@
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle is required"
-                            (user/create-human! store ""))))))
+                            (user/create-human! store "")))))
+
+  (testing "allows letters numbers hyphens and underscores in handles"
+    (let [store (user/create-store)]
+      (is (= #:user{:handle "andres_42-test"
+                    :type :user.type/human}
+             (user/create-human! store "andres_42-test")))))
+
+  (testing "rejects unsupported handle characters"
+    (let [store (user/create-store)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle has unsupported characters"
+                            (user/create-human! store "andres.test"))))))
 
 (deftest list-users-in-store
   (testing "lists created users ordered by handle"

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -30,3 +30,11 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle is required"
                             (user/create-human! store ""))))))
+
+(deftest list-users-in-store
+  (testing "lists created users ordered by handle"
+    (let [store (user/create-store)
+          zoe (user/create-human! store "zoe")
+          andres (user/create-human! store "andres")]
+      (is (= [andres zoe]
+             (user/list-users store))))))

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -7,3 +7,20 @@
     (is (= #:user{:handle "andres"
                   :type :user.type/human}
            (user/create-human "andres")))))
+
+(deftest create-human-user-in-store
+  (testing "persists a human user with a unique handle"
+    (let [store (user/create-store)
+          created-user (user/create-human! store "andres")]
+      (is (= #:user{:handle "andres"
+                    :type :user.type/human}
+             created-user))
+      (is (= created-user
+             (user/find-by-handle store "andres")))))
+
+  (testing "rejects duplicated handles"
+    (let [store (user/create-store)]
+      (user/create-human! store "andres")
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle already exists"
+                            (user/create-human! store "andres"))))))

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -25,6 +25,16 @@
                             #"handle already exists"
                             (user/create-human! store "andres")))))
 
+  (testing "normalizes handles before enforcing uniqueness"
+    (let [store (user/create-store)
+          created-user (user/create-human! store " andres ")]
+      (is (= #:user{:handle "andres"
+                    :type :user.type/human}
+             created-user))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle already exists"
+                            (user/create-human! store "andres")))))
+
   (testing "rejects blank handles"
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -35,6 +35,16 @@
                             #"handle already exists"
                             (user/create-human! store "andres")))))
 
+  (testing "enforces handle uniqueness case-insensitively"
+    (let [store (user/create-store)
+          created-user (user/create-human! store "Andres")]
+      (is (= #:user{:handle "andres"
+                    :type :user.type/human}
+             created-user))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle already exists"
+                            (user/create-human! store "andres")))))
+
   (testing "rejects blank handles"
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -23,4 +23,10 @@
       (user/create-human! store "andres")
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle already exists"
-                            (user/create-human! store "andres"))))))
+                            (user/create-human! store "andres")))))
+
+  (testing "rejects blank handles"
+    (let [store (user/create-store)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle is required"
+                            (user/create-human! store ""))))))


### PR DESCRIPTION
Refs #14

## Resumen
- persiste usuarios humanos por handle en un store in-memory inicial
- rechaza handles duplicados
- conserva el tipo `:user.type/human`
- actualiza el procedimiento para crear branches desde GitHub

## Checks
- clj-kondo --lint src test
- clojure -M:test
- npx markdownlint-cli2 '**/*.md' '#node_modules'