### PR TITLE
feat(domain): reject invalid user handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Labels principales:
 
 Historia activa:
 
-- [#14 Como usuario, quiero crearme con un handle](https://github.com/andrestobelem/pi-clojure/issues/14)
+- [#22 Como usuario, quiero que no se creen usuarios con handles inválidos](https://github.com/andrestobelem/pi-clojure/issues/22)
 
 Procedimiento de trabajo:
 
@@ -121,7 +121,7 @@ con:
 gh project view 2 --owner andrestobelem --format json --jq '.id'
 gh project field-list 2 --owner andrestobelem --format json
 gh project item-list 2 --owner andrestobelem --format json --limit 100 \
-  --jq '.items[] | select(.content.number==14) | {id, status:.status, title:.content.title}'
+  --jq '.items[] | select(.content.number==22) | {id, status:.status, title:.content.title}'
 ```
 
 Mover un item a `Done`:

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -6,6 +6,7 @@
 (def max-handle-length 39)
 (def allowed-handle-pattern #"[a-z0-9_-]+")
 (def edge-separator-pattern #"(^[-_]|[-_]$)")
+(def consecutive-separator-pattern #"[-_]{2}")
 
 (defn required-handle? [handle]
   (and (string? handle)
@@ -26,13 +27,17 @@
 (defn without-edge-separators? [handle]
   (not (re-find edge-separator-pattern handle)))
 
+(defn without-consecutive-separators? [handle]
+  (not (re-find consecutive-separator-pattern handle)))
+
 (defn valid-handle? [handle]
   (and (required-handle? handle)
        (without-surrounding-whitespace? handle)
        (lowercase-handle? handle)
        (handle-length-valid? handle)
        (supported-handle-characters? handle)
-       (without-edge-separators? handle)))
+       (without-edge-separators? handle)
+       (without-consecutive-separators? handle)))
 
 (def user-types #{:user.type/human
                   :user.type/agent})
@@ -72,6 +77,9 @@
     (throw (ex-info "handle has unsupported characters" {:handle handle})))
   (when-not (without-edge-separators? handle)
     (throw (ex-info "handle cannot start or end with a separator"
+                    {:handle handle})))
+  (when-not (without-consecutive-separators? handle)
+    (throw (ex-info "handle cannot contain consecutive separators"
                     {:handle handle}))))
 
 (defn create-user! [store handle user-type]

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -14,13 +14,16 @@
        (boolean (re-matches #"[a-z0-9_-]+" handle))
        (not (re-find #"(^[-_]|[-_]$)" handle))))
 
+(def user-types #{:user.type/human
+                  :user.type/agent})
+
 (s/def :user/handle valid-handle?)
-(s/def :user/type #{:user.type/human})
+(s/def :user/type user-types)
 (s/def :user/user (s/keys :req [:user/handle :user/type]))
 
-(defn create-human [handle]
+(defn create-user [handle user-type]
   #:user{:handle handle
-         :type :user.type/human})
+         :type user-type})
 
 (defn create-store []
   (atom #:users{:by-handle {}}))
@@ -51,10 +54,10 @@
     (throw (ex-info "handle cannot start or end with a separator"
                     {:handle handle}))))
 
-(defn create-human! [store handle]
+(defn create-user! [store handle user-type]
   (validate-handle! handle)
-  (let [human-user (create-human handle)]
+  (let [created-user (create-user handle user-type)]
     (when (find-by-handle store handle)
       (throw (ex-info "handle already exists" {:handle handle})))
-    (swap! store assoc-in [:users/by-handle handle] human-user)
-    human-user))
+    (swap! store assoc-in [:users/by-handle handle] created-user)
+    created-user))

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -28,6 +28,9 @@
     (when-not (re-matches #"[a-z0-9_-]+" normalized-handle)
       (throw (ex-info "handle has unsupported characters"
                       {:handle normalized-handle})))
+    (when (re-find #"(^[-_]|[-_]$)" normalized-handle)
+      (throw (ex-info "handle cannot start or end with a separator"
+                      {:handle normalized-handle})))
     (when (find-by-handle store normalized-handle)
       (throw (ex-info "handle already exists" {:handle normalized-handle})))
     (swap! store assoc-in [:users/by-handle normalized-handle] human-user)

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -21,6 +21,10 @@
     (throw (ex-info "handle is required" {:handle handle})))
   (let [normalized-handle (-> handle str/trim str/lower-case)
         human-user (create-human normalized-handle)]
+    (when (< (count normalized-handle) 3)
+      (throw (ex-info "handle is too short" {:handle normalized-handle})))
+    (when (> (count normalized-handle) 39)
+      (throw (ex-info "handle is too long" {:handle normalized-handle})))
     (when-not (re-matches #"[a-z0-9_-]+" normalized-handle)
       (throw (ex-info "handle has unsupported characters"
                       {:handle normalized-handle})))

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -4,9 +4,6 @@
 (def min-handle-length 3)
 (def max-handle-length 39)
 
-(defn normalize-handle [handle]
-  (some-> handle str/trim str/lower-case))
-
 (defn create-human [handle]
   #:user{:handle handle
          :type :user.type/human})
@@ -25,6 +22,11 @@
 (defn validate-handle! [handle]
   (when (str/blank? handle)
     (throw (ex-info "handle is required" {:handle handle})))
+  (when (not= handle (str/trim handle))
+    (throw (ex-info "handle cannot have surrounding whitespace"
+                    {:handle handle})))
+  (when (not= handle (str/lower-case handle))
+    (throw (ex-info "handle must be lowercase" {:handle handle})))
   (when (< (count handle) min-handle-length)
     (throw (ex-info "handle is too short" {:handle handle})))
   (when (> (count handle) max-handle-length)
@@ -36,10 +38,9 @@
                     {:handle handle}))))
 
 (defn create-human! [store handle]
-  (let [normalized-handle (normalize-handle handle)
-        human-user (create-human normalized-handle)]
-    (validate-handle! normalized-handle)
-    (when (find-by-handle store normalized-handle)
-      (throw (ex-info "handle already exists" {:handle normalized-handle})))
-    (swap! store assoc-in [:users/by-handle normalized-handle] human-user)
+  (validate-handle! handle)
+  (let [human-user (create-human handle)]
+    (when (find-by-handle store handle)
+      (throw (ex-info "handle already exists" {:handle handle})))
+    (swap! store assoc-in [:users/by-handle handle] human-user)
     human-user))

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -7,6 +7,11 @@
 (def allowed-handle-pattern #"[a-z0-9_-]+")
 (def edge-separator-pattern #"(^[-_]|[-_]$)")
 (def consecutive-separator-pattern #"[-_]{2}")
+(def reserved-handles #{"admin"
+                        "api"
+                        "root"
+                        "support"
+                        "www"})
 
 (defn required-handle? [handle]
   (and (string? handle)
@@ -30,6 +35,9 @@
 (defn without-consecutive-separators? [handle]
   (not (re-find consecutive-separator-pattern handle)))
 
+(defn available-handle-name? [handle]
+  (not (contains? reserved-handles handle)))
+
 (defn valid-handle? [handle]
   (and (required-handle? handle)
        (without-surrounding-whitespace? handle)
@@ -37,7 +45,8 @@
        (handle-length-valid? handle)
        (supported-handle-characters? handle)
        (without-edge-separators? handle)
-       (without-consecutive-separators? handle)))
+       (without-consecutive-separators? handle)
+       (available-handle-name? handle)))
 
 (def user-types #{:user.type/human
                   :user.type/agent})
@@ -80,7 +89,9 @@
                     {:handle handle})))
   (when-not (without-consecutive-separators? handle)
     (throw (ex-info "handle cannot contain consecutive separators"
-                    {:handle handle}))))
+                    {:handle handle})))
+  (when-not (available-handle-name? handle)
+    (throw (ex-info "handle is reserved" {:handle handle}))))
 
 (defn create-user! [store handle user-type]
   (validate-handle! handle)

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -4,15 +4,35 @@
 
 (def min-handle-length 3)
 (def max-handle-length 39)
+(def allowed-handle-pattern #"[a-z0-9_-]+")
+(def edge-separator-pattern #"(^[-_]|[-_]$)")
+
+(defn required-handle? [handle]
+  (and (string? handle)
+       (not (str/blank? handle))))
+
+(defn without-surrounding-whitespace? [handle]
+  (= handle (str/trim handle)))
+
+(defn lowercase-handle? [handle]
+  (= handle (str/lower-case handle)))
+
+(defn handle-length-valid? [handle]
+  (<= min-handle-length (count handle) max-handle-length))
+
+(defn supported-handle-characters? [handle]
+  (boolean (re-matches allowed-handle-pattern handle)))
+
+(defn without-edge-separators? [handle]
+  (not (re-find edge-separator-pattern handle)))
 
 (defn valid-handle? [handle]
-  (and (string? handle)
-       (not (str/blank? handle))
-       (= handle (str/trim handle))
-       (= handle (str/lower-case handle))
-       (<= min-handle-length (count handle) max-handle-length)
-       (boolean (re-matches #"[a-z0-9_-]+" handle))
-       (not (re-find #"(^[-_]|[-_]$)" handle))))
+  (and (required-handle? handle)
+       (without-surrounding-whitespace? handle)
+       (lowercase-handle? handle)
+       (handle-length-valid? handle)
+       (supported-handle-characters? handle)
+       (without-edge-separators? handle)))
 
 (def user-types #{:user.type/human
                   :user.type/agent})
@@ -37,20 +57,20 @@
        (mapv val)))
 
 (defn validate-handle! [handle]
-  (when (str/blank? handle)
+  (when-not (required-handle? handle)
     (throw (ex-info "handle is required" {:handle handle})))
-  (when (not= handle (str/trim handle))
+  (when-not (without-surrounding-whitespace? handle)
     (throw (ex-info "handle cannot have surrounding whitespace"
                     {:handle handle})))
-  (when (not= handle (str/lower-case handle))
+  (when-not (lowercase-handle? handle)
     (throw (ex-info "handle must be lowercase" {:handle handle})))
   (when (< (count handle) min-handle-length)
     (throw (ex-info "handle is too short" {:handle handle})))
   (when (> (count handle) max-handle-length)
     (throw (ex-info "handle is too long" {:handle handle})))
-  (when-not (re-matches #"[a-z0-9_-]+" handle)
+  (when-not (supported-handle-characters? handle)
     (throw (ex-info "handle has unsupported characters" {:handle handle})))
-  (when (re-find #"(^[-_]|[-_]$)" handle)
+  (when-not (without-edge-separators? handle)
     (throw (ex-info "handle cannot start or end with a separator"
                     {:handle handle}))))
 

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -1,6 +1,12 @@
 (ns pi-clojure.domain.user
   (:require [clojure.string :as str]))
 
+(def min-handle-length 3)
+(def max-handle-length 39)
+
+(defn normalize-handle [handle]
+  (some-> handle str/trim str/lower-case))
+
 (defn create-human [handle]
   #:user{:handle handle
          :type :user.type/human})
@@ -16,21 +22,23 @@
        (sort-by key)
        (mapv val)))
 
-(defn create-human! [store handle]
+(defn validate-handle! [handle]
   (when (str/blank? handle)
     (throw (ex-info "handle is required" {:handle handle})))
-  (let [normalized-handle (-> handle str/trim str/lower-case)
+  (when (< (count handle) min-handle-length)
+    (throw (ex-info "handle is too short" {:handle handle})))
+  (when (> (count handle) max-handle-length)
+    (throw (ex-info "handle is too long" {:handle handle})))
+  (when-not (re-matches #"[a-z0-9_-]+" handle)
+    (throw (ex-info "handle has unsupported characters" {:handle handle})))
+  (when (re-find #"(^[-_]|[-_]$)" handle)
+    (throw (ex-info "handle cannot start or end with a separator"
+                    {:handle handle}))))
+
+(defn create-human! [store handle]
+  (let [normalized-handle (normalize-handle handle)
         human-user (create-human normalized-handle)]
-    (when (< (count normalized-handle) 3)
-      (throw (ex-info "handle is too short" {:handle normalized-handle})))
-    (when (> (count normalized-handle) 39)
-      (throw (ex-info "handle is too long" {:handle normalized-handle})))
-    (when-not (re-matches #"[a-z0-9_-]+" normalized-handle)
-      (throw (ex-info "handle has unsupported characters"
-                      {:handle normalized-handle})))
-    (when (re-find #"(^[-_]|[-_]$)" normalized-handle)
-      (throw (ex-info "handle cannot start or end with a separator"
-                      {:handle normalized-handle})))
+    (validate-handle! normalized-handle)
     (when (find-by-handle store normalized-handle)
       (throw (ex-info "handle already exists" {:handle normalized-handle})))
     (swap! store assoc-in [:users/by-handle normalized-handle] human-user)

--- a/src/pi_clojure/domain/user.clj
+++ b/src/pi_clojure/domain/user.clj
@@ -1,8 +1,22 @@
 (ns pi-clojure.domain.user
-  (:require [clojure.string :as str]))
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
 
 (def min-handle-length 3)
 (def max-handle-length 39)
+
+(defn valid-handle? [handle]
+  (and (string? handle)
+       (not (str/blank? handle))
+       (= handle (str/trim handle))
+       (= handle (str/lower-case handle))
+       (<= min-handle-length (count handle) max-handle-length)
+       (boolean (re-matches #"[a-z0-9_-]+" handle))
+       (not (re-find #"(^[-_]|[-_]$)" handle))))
+
+(s/def :user/handle valid-handle?)
+(s/def :user/type #{:user.type/human})
+(s/def :user/user (s/keys :req [:user/handle :user/type]))
 
 (defn create-human [handle]
   #:user{:handle handle

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -3,96 +3,113 @@
             [clojure.test :refer [deftest is testing]]
             [pi-clojure.domain.user :as user]))
 
-(deftest create-human-user-with-handle
-  (testing "creates a human user with the provided handle"
+(deftest create-user-with-handle-and-type
+  (testing "given a handle and human type, when creating a user, then it returns a human user"
     (is (= #:user{:handle "andres"
                   :type :user.type/human}
-           (user/create-human "andres")))))
+           (user/create-user "andres" :user.type/human))))
+
+  (testing "given a handle and agent type, when creating a user, then it returns an agent user"
+    (is (= #:user{:handle "agent"
+                  :type :user.type/agent}
+           (user/create-user "agent" :user.type/agent)))))
 
 (deftest user-specs
-  (testing "validates canonical handles"
+  (testing "given canonical and non-canonical handles, when validating handle spec, then only canonical handles are valid"
     (is (s/valid? :user/handle "andres_42-test"))
     (is (not (s/valid? :user/handle "Andres")))
     (is (not (s/valid? :user/handle " andres")))
     (is (not (s/valid? :user/handle "andres."))))
 
-  (testing "validates human users"
+  (testing "given a human user, when validating user spec, then it is valid"
     (is (s/valid? :user/user
                   #:user{:handle "andres"
-                         :type :user.type/human}))))
+                         :type :user.type/human})))
 
-(deftest create-human-user-in-store
-  (testing "persists a human user with a unique handle"
+  (testing "given an agent user, when validating user spec, then it is valid"
+    (is (s/valid? :user/user
+                  #:user{:handle "agent"
+                         :type :user.type/agent}))))
+
+(deftest create-user-in-store
+  (testing "given an empty store, when creating a user, then it persists the user by handle"
     (let [store (user/create-store)
-          created-user (user/create-human! store "andres")]
+          created-user (user/create-user! store "andres" :user.type/human)]
       (is (= #:user{:handle "andres"
                     :type :user.type/human}
              created-user))
       (is (= created-user
              (user/find-by-handle store "andres")))))
 
-  (testing "rejects duplicated handles"
+  (testing "given an empty store, when creating an agent user, then it preserves the agent type"
+    (let [store (user/create-store)
+          created-user (user/create-user! store "agent" :user.type/agent)]
+      (is (= #:user{:handle "agent"
+                    :type :user.type/agent}
+             created-user))))
+
+  (testing "given an existing handle, when creating another user with the same handle, then it rejects the duplicate"
     (let [store (user/create-store)]
-      (user/create-human! store "andres")
+      (user/create-user! store "andres" :user.type/human)
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle already exists"
-                            (user/create-human! store "andres")))))
+                            (user/create-user! store "andres" :user.type/agent)))))
 
-  (testing "rejects handles with surrounding whitespace"
+  (testing "given a handle with surrounding whitespace, when creating a user, then it rejects the handle"
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle cannot have surrounding whitespace"
-                            (user/create-human! store " andres ")))))
+                            (user/create-user! store " andres " :user.type/human)))))
 
-  (testing "rejects handles with uppercase letters"
+  (testing "given a handle with uppercase letters, when creating a user, then it rejects the handle"
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle must be lowercase"
-                            (user/create-human! store "Andres")))))
+                            (user/create-user! store "Andres" :user.type/human)))))
 
-  (testing "rejects blank handles"
+  (testing "given a blank handle, when creating a user, then it rejects the handle"
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle is required"
-                            (user/create-human! store "")))))
+                            (user/create-user! store "" :user.type/human)))))
 
-  (testing "allows letters numbers hyphens and underscores in handles"
+  (testing "given a handle with allowed characters, when creating a user, then it accepts the handle"
     (let [store (user/create-store)]
       (is (= #:user{:handle "andres_42-test"
                     :type :user.type/human}
-             (user/create-human! store "andres_42-test")))))
+             (user/create-user! store "andres_42-test" :user.type/human)))))
 
-  (testing "rejects unsupported handle characters"
+  (testing "given a handle with unsupported characters, when creating a user, then it rejects the handle"
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle has unsupported characters"
-                            (user/create-human! store "andres.test")))))
+                            (user/create-user! store "andres.test" :user.type/human)))))
 
-  (testing "rejects handles shorter than 3 characters"
+  (testing "given a handle shorter than 3 characters, when creating a user, then it rejects the handle"
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle is too short"
-                            (user/create-human! store "ab")))))
+                            (user/create-user! store "ab" :user.type/human)))))
 
-  (testing "rejects handles longer than 39 characters"
+  (testing "given a handle longer than 39 characters, when creating a user, then it rejects the handle"
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle is too long"
-                            (user/create-human! store "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")))))
+                            (user/create-user! store "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" :user.type/human)))))
 
-  (testing "rejects handles that start or end with separators"
+  (testing "given a handle that starts or ends with a separator, when creating a user, then it rejects the handle"
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle cannot start or end with a separator"
-                            (user/create-human! store "-andres")))
+                            (user/create-user! store "-andres" :user.type/human)))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle cannot start or end with a separator"
-                            (user/create-human! store "andres_"))))))
+                            (user/create-user! store "andres_" :user.type/human))))))
 
 (deftest list-users-in-store
-  (testing "lists created users ordered by handle"
+  (testing "given users created out of order, when listing users, then it returns them ordered by handle"
     (let [store (user/create-store)
-          zoe (user/create-human! store "zoe")
-          andres (user/create-human! store "andres")]
+          zoe (user/create-user! store "zoe" :user.type/human)
+          andres (user/create-user! store "andres" :user.type/human)]
       (is (= [andres zoe]
              (user/list-users store))))))

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -61,7 +61,19 @@
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle has unsupported characters"
-                            (user/create-human! store "andres.test"))))))
+                            (user/create-human! store "andres.test")))))
+
+  (testing "rejects handles shorter than 3 characters"
+    (let [store (user/create-store)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle is too short"
+                            (user/create-human! store "ab")))))
+
+  (testing "rejects handles longer than 39 characters"
+    (let [store (user/create-store)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle is too long"
+                            (user/create-human! store "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))))))
 
 (deftest list-users-in-store
   (testing "lists created users ordered by handle"

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -25,25 +25,17 @@
                             #"handle already exists"
                             (user/create-human! store "andres")))))
 
-  (testing "normalizes handles before enforcing uniqueness"
-    (let [store (user/create-store)
-          created-user (user/create-human! store " andres ")]
-      (is (= #:user{:handle "andres"
-                    :type :user.type/human}
-             created-user))
+  (testing "rejects handles with surrounding whitespace"
+    (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"handle already exists"
-                            (user/create-human! store "andres")))))
+                            #"handle cannot have surrounding whitespace"
+                            (user/create-human! store " andres ")))))
 
-  (testing "enforces handle uniqueness case-insensitively"
-    (let [store (user/create-store)
-          created-user (user/create-human! store "Andres")]
-      (is (= #:user{:handle "andres"
-                    :type :user.type/human}
-             created-user))
+  (testing "rejects handles with uppercase letters"
+    (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"handle already exists"
-                            (user/create-human! store "andres")))))
+                            #"handle must be lowercase"
+                            (user/create-human! store "Andres")))))
 
   (testing "rejects blank handles"
     (let [store (user/create-store)]

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -119,7 +119,16 @@
                             (user/create-user! store "andres-_test" :user.type/human)))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle cannot contain consecutive separators"
-                            (user/create-user! store "andres_-test" :user.type/human))))))
+                            (user/create-user! store "andres_-test" :user.type/human)))))
+
+  (testing "given a reserved handle, when creating a user, then it rejects the handle"
+    (let [store (user/create-store)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle is reserved"
+                            (user/create-user! store "admin" :user.type/human)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle is reserved"
+                            (user/create-user! store "support" :user.type/human))))))
 
 (deftest list-users-in-store
   (testing "given users created out of order, when listing users, then it returns them ordered by handle"

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -73,7 +73,16 @@
     (let [store (user/create-store)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle is too long"
-                            (user/create-human! store "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))))))
+                            (user/create-human! store "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")))))
+
+  (testing "rejects handles that start or end with separators"
+    (let [store (user/create-store)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle cannot start or end with a separator"
+                            (user/create-human! store "-andres")))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle cannot start or end with a separator"
+                            (user/create-human! store "andres_"))))))
 
 (deftest list-users-in-store
   (testing "lists created users ordered by handle"

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -1,5 +1,6 @@
 (ns pi-clojure.domain.user-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test :refer [deftest is testing]]
             [pi-clojure.domain.user :as user]))
 
 (deftest create-human-user-with-handle
@@ -7,6 +8,18 @@
     (is (= #:user{:handle "andres"
                   :type :user.type/human}
            (user/create-human "andres")))))
+
+(deftest user-specs
+  (testing "validates canonical handles"
+    (is (s/valid? :user/handle "andres_42-test"))
+    (is (not (s/valid? :user/handle "Andres")))
+    (is (not (s/valid? :user/handle " andres")))
+    (is (not (s/valid? :user/handle "andres."))))
+
+  (testing "validates human users"
+    (is (s/valid? :user/user
+                  #:user{:handle "andres"
+                         :type :user.type/human}))))
 
 (deftest create-human-user-in-store
   (testing "persists a human user with a unique handle"

--- a/test/pi_clojure/domain/user_test.clj
+++ b/test/pi_clojure/domain/user_test.clj
@@ -104,7 +104,22 @@
                             (user/create-user! store "-andres" :user.type/human)))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"handle cannot start or end with a separator"
-                            (user/create-user! store "andres_" :user.type/human))))))
+                            (user/create-user! store "andres_" :user.type/human)))))
+
+  (testing "given a handle with consecutive separators, when creating a user, then it rejects the handle"
+    (let [store (user/create-store)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle cannot contain consecutive separators"
+                            (user/create-user! store "andres--test" :user.type/human)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle cannot contain consecutive separators"
+                            (user/create-user! store "andres__test" :user.type/human)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle cannot contain consecutive separators"
+                            (user/create-user! store "andres-_test" :user.type/human)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"handle cannot contain consecutive separators"
+                            (user/create-user! store "andres_-test" :user.type/human))))))
 
 (deftest list-users-in-store
   (testing "given users created out of order, when listing users, then it returns them ordered by handle"


### PR DESCRIPTION
Refs #22

## Resumen
- rechaza handles no canónicos en vez de normalizarlos silenciosamente
- valida longitud, caracteres permitidos, separadores en bordes y separadores consecutivos
- rechaza handles reservados
- agrega specs de usuario y soporte para tipos humano/agente

## Checks
- clj-kondo --lint src test
- clojure -M:test
- npx markdownlint-cli2 '**/*.md' '#node_modules'